### PR TITLE
Firefox

### DIFF
--- a/lib/BWCall.js
+++ b/lib/BWCall.js
@@ -144,10 +144,12 @@ function BWCall(data) {
 	function configureDTMF () {
 		var peerConnection = data.session.mediaHandler.peerConnection;
 		var localStreams = data.session.mediaHandler.getLocalStreams();
-		dtmfSenders = _.map(localStreams, function (stream) {
-			var track = stream.getAudioTracks()[ 0 ];
-			return peerConnection.createDTMFSender(track);
-		});
+		for (var a = 0; a < localStreams.length; a += 1){
+			if (peerConnection.createDTMFSender){
+				var track = localStreams[a].getAudioTracks()[ 0 ];
+				dtmfSenders.push(peerConnection.createDTMFSender(track));
+			}
+		}
 	}
 
 	function onCallEnded () {

--- a/lib/BWClient.js
+++ b/lib/BWClient.js
@@ -26,6 +26,12 @@ BWClient.prototype.requestNotificationPermission = function () {
 	}
 };
 BWClient.prototype.getMicrophones = function () {
+	if (!global.MediaStreamTrack.getSources) {
+		return Promise.resolve([ {
+			id   : null,
+			name : "Default"
+		} ]);
+	}
 	return new Promise(function (resolve,reject) {
 		global.navigator.getUserMedia = global.navigator.getUserMedia ||
 			global.navigator.webkitGetUserMedia || global.navigator.mozGetUserMedia;

--- a/lib/BWPhone.js
+++ b/lib/BWPhone.js
@@ -87,7 +87,7 @@ function BWPhone(config) {
 		bwCall.on("ended", stopIncomingCallRing);
 		self.emit("incomingCall",bwCall);
 	});
-	var incomingCallAudio =  new global.Audio(globalConfig.incomingcallAudio);
+	var incomingCallAudio =  new global.Audio(globalConfig.incomingCallAudio);
 
 	function playIncomingCallRing () {
 		incomingCallAudio.currentTime = 0;

--- a/test/unit/BWCall.js
+++ b/test/unit/BWCall.js
@@ -147,6 +147,38 @@ describe("BWCall", function () {
 			expect(userAgentMock.session.unmute.calledOnce).to.equal(true);
 		});
 	});
+	describe(".dtmf() (without createDTMFSender)",function () {
+		var bwCall;
+		var userAgent;
+		before(function (done) {
+			userAgent = new UserAgentMock();
+			sinon.spy(userAgent.dtmfSender,"insertDTMF");
+			userAgent.session.mediaHandler.peerConnection.createDTMFSender = undefined;
+			bwCall = new BWCall({
+				info      :{
+					direction : "out",
+					localUri  : "localUri",
+					localId   : "localId",
+					remoteUri : "remoteUri",
+					remoteId  : "remoteId"
+				},
+				userAgent : userAgent
+			});
+			bwCall.on("connected",function () {
+				bwCall.sendDtmf("1");
+				done();
+			});
+			bwCall.on("connecting",function () {
+				userAgent.mockReceiveAccept();
+			});
+		});
+		after(function () {
+			userAgent.dtmfSender.insertDTMF.restore();
+		});
+		it("should not send dtmf",function () {
+			expect(userAgent.dtmfSender.insertDTMF.called).to.equal(false);
+		});
+	});
 	describe(".accept() (valid)",function () {
 		var bwCall;
 		var session;

--- a/test/unit/BWClient.js
+++ b/test/unit/BWClient.js
@@ -131,6 +131,31 @@ describe("BWClient", function () {
 			expect(output.length).to.equal(1);
 		});
 	});
+	describe(".getMicrophones() [not supported]",function () {
+		var output;
+		var getSources;
+		before(function (done) {
+			getSources = global.MediaStreamTrack.getSources;
+			global.MediaStreamTrack.getSources = undefined;
+			global.BWClient.getMicrophones()
+			.then(function (mics) {
+				output = mics;
+				done();
+			})
+			.catch(function (err) {
+				throw err;
+			});
+		});
+		after(function () {
+			global.MediaStreamTrack.getSources = getSources;
+		});
+		it("output should contain only 'Default'",function () {
+			expect(output).to.deep.equal([ {
+				id   : null,
+				name : "Default"
+			} ]);
+		});
+	});
 	describe("webkitGetUserMedia",function () {
 		before(function (done) {
 			global.navigator.getUserMedia = null;


### PR DESCRIPTION
fix getting microphones and DTMF on browsers that don't support `createDTMFSender` and `getSources`. For now, DTMF is ignored, and `getMicrophones` will return a single 'Default' microphone.